### PR TITLE
rename vhs viewhelper namespace

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -1,4 +1,4 @@
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 
 <f:if condition="{settings.cssfile}">
 	<f:then>

--- a/Resources/Private/Partials/Slideshare/AjaxComponents.html
+++ b/Resources/Private/Partials/Slideshare/AjaxComponents.html
@@ -1,7 +1,7 @@
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 
 <f:section name="init">
-	<v:var.set name="ajaxurl" value="{v:site.url()}{f:uri.page(pageUid: currentpid)}" />
+	<v:variable.set name="ajaxurl" value="{v:site.url()}{f:uri.page(pageUid: currentpid)}" />
 	<v:asset.script name="moox-social-slideshare-js" group="moox-social" path="typo3conf/ext/moox_social/Resources/Public/Js/slideshare.js" fluid="1" arguments="{ajaxurl: ajaxurl, source: settings.source, page: settings.api_user_id}" allowMoveToFooter="TRUE" standalone="TRUE" />
 	<div id="tx-moox-social-slideshare-ajaxquery"></div>
 	<input type="hidden" id="tx-moox-social-slideshare-count" value="{count}" />

--- a/Resources/Private/Templates/Facebook/List.html
+++ b/Resources/Private/Templates/Facebook/List.html
@@ -1,4 +1,4 @@
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 
 <f:layout name="Default" />
 

--- a/Resources/Private/Templates/Flickr/List.html
+++ b/Resources/Private/Templates/Flickr/List.html
@@ -1,4 +1,4 @@
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 
 <f:layout name="Default" />
 

--- a/Resources/Private/Templates/Slideshare/List.html
+++ b/Resources/Private/Templates/Slideshare/List.html
@@ -1,4 +1,4 @@
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 
 <f:layout name="Default" />
 

--- a/Resources/Private/Templates/Twitter/List.html
+++ b/Resources/Private/Templates/Twitter/List.html
@@ -1,4 +1,4 @@
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 
 <f:layout name="Default" />
 

--- a/Resources/Private/Templates/Youtube/List.html
+++ b/Resources/Private/Templates/Youtube/List.html
@@ -1,4 +1,4 @@
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 
 <f:layout name="Default" />
 

--- a/Resources/Private/__Elements/FacebookLogin.html
+++ b/Resources/Private/__Elements/FacebookLogin.html
@@ -8,7 +8,7 @@
 - - - - - - - - - - - - - - - - - - - - - - - - - - -
 </f:comment>
 
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 {namespace flux=Tx_Flux_ViewHelpers}
 {namespace s=Tx_MooxSocial_ViewHelpers}
 

--- a/Resources/Private/__Elements/Slideshare.html
+++ b/Resources/Private/__Elements/Slideshare.html
@@ -8,7 +8,7 @@
 - - - - - - - - - - - - - - - - - - - - - - - - - - -
 </f:comment>
 
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 {namespace flux=Tx_Flux_ViewHelpers}
 {namespace s=Tx_MooxSocial_ViewHelpers}
 

--- a/Resources/Private/__Elements/Twitter.html
+++ b/Resources/Private/__Elements/Twitter.html
@@ -8,7 +8,7 @@
 - - - - - - - - - - - - - - - - - - - - - - - - - - -
 </f:comment>
 
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 {namespace flux=Tx_Flux_ViewHelpers}
 {namespace s=Tx_MooxSocial_ViewHelpers}
 

--- a/Resources/Private/__Elements/YouTube.html
+++ b/Resources/Private/__Elements/YouTube.html
@@ -8,7 +8,7 @@
 - - - - - - - - - - - - - - - - - - - - - - - - - - -
 </f:comment>
 
-{namespace v=Tx_Vhs_ViewHelpers}
+{namespace v=FluidTYPO3\Vhs\ViewHelpers}
 {namespace flux=Tx_Flux_ViewHelpers}
 {namespace s=Tx_MooxSocial_ViewHelpers}
 


### PR DESCRIPTION
Hi,

today i installed moox_social extention in a new typoe 6.2 and i got errors because the namespace for the vhs viewhelper. So i tried to fix it in every file with a little help from this irclog https://fluidtypo3.org/community/irc-logs.html?tx_fluidtypo3org_content%5Bdate%5D=20140614&tx_fluidtypo3org_content%5Bcontroller%5D=Content&cHash=dfa3fc5d687b9b2fa675f4f94a06c46d

Regards
bullshit